### PR TITLE
Make sure pathSep is not undefined on iOS

### DIFF
--- a/src/obsidianScholar.ts
+++ b/src/obsidianScholar.ts
@@ -16,7 +16,7 @@ export class ObsidianScholar {
 	) {
 		this.app = app;
 		this.settings = settings;
-		this.pathSep = pathSep;
+		this.pathSep = pathSep ? pathSep : "/";
 	}
 
 	constructFileName(paperData: StructuredPaperData): string {
@@ -122,7 +122,6 @@ export class ObsidianScholar {
 		if (paperData.bibtex && paperData.bibtex !== "") {
 			return paperData.bibtex;
 		}
-		
 		if (paperData.citekey && paperData.citekey !== "") {
 			return await this.extractPaperBibtexFromFile(paperData.citekey);
 		}


### PR DESCRIPTION
Issue: sometimes on iOS, the path.sep can be undefined thus leading to errors when creating the new note files. We solve this by enforcing using `/` by default. However this is not properly tested on windows/android ...

PS: use `path.join` won't solve this issue for now. 