### PR TITLE
Fix: Improvements based on plugin library listing auditing 

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -6,6 +6,7 @@ import {
 	Plugin,
 	TFile,
 	Setting,
+	Platform,
 } from "obsidian";
 import {
 	StructuredPaperData,
@@ -38,14 +39,13 @@ import {
 	NOTICE_PAPER_NOTE_DOWNLOAD_ERROR,
 	NOTICE_DOWNLOADING_S2,
 } from "./constants";
-import { isValidUrl } from "./utility";
+import { isValidUrl, getSystemPathSeparator } from "./utility";
 import {
 	ObsidianScholarSettingTab,
 	ObsidianScholarPluginSettings,
 	DEFAULT_SETTINGS,
 } from "./settingsTab";
 import { ObsidianScholar } from "./obsidianScholar";
-import * as path from "path";
 
 // Main Plugin Entry Point
 export default class ObsidianScholarPlugin extends Plugin {
@@ -59,7 +59,7 @@ export default class ObsidianScholarPlugin extends Plugin {
 		this.obsidianScholar = new ObsidianScholar(
 			this.app,
 			this.settings,
-			path.sep
+			getSystemPathSeparator(),
 		);
 
 		this.addCommand({
@@ -191,7 +191,7 @@ export default class ObsidianScholarPlugin extends Plugin {
 			checkCallback: (checking: boolean) => {
 				const currentFile = this.app.workspace.getActiveFile();
 
-				if (!currentFile) {
+				if (!currentFile || !Platform.isMacOS) {
 					return false;
 				} else {
 					if (!checking) {

--- a/src/utility.ts
+++ b/src/utility.ts
@@ -1,3 +1,5 @@
+import {Platform} from "obsidian";
+
 export function getDate(input?: { format?: string; offset?: number }) {
 	let duration;
 
@@ -29,4 +31,8 @@ export function isValidUrl(s: string) {
 export function splitBibtex(bibtex:string): string[] | null {
     let regex = /(@.*?{[^@]*})/gs;
     return bibtex.match(regex);
+}
+
+export function getSystemPathSeparator(): string {
+	return Platform.isWin? "\\" : "/";
 }


### PR DESCRIPTION
Updates based on https://github.com/obsidianmd/obsidian-releases/pull/2525 :
- More robust multi-platform support 
- Use `this.scope.register` to register events 
- Use sentence case for prompt text 
- More robust file loading by type checking before `this.app.vault.getAbstractFileByPath(file) as TFile`
- Remove header with the plugin name in the settings
