### PR TITLE
Fix: Ignore styles.css

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -147,3 +147,5 @@ dist
 .yarn/build-state.yml
 .yarn/install-state.gz
 .pnp.*
+
+styles.css

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ dev-obsidian-scholar/
 # Don't include the compiled main.js file in the repo.
 # They should be uploaded to GitHub releases instead.
 main.js
+styles.css
 
 # Exclude sourcemaps
 *.map
@@ -147,5 +148,3 @@ dist
 .yarn/build-state.yml
 .yarn/install-state.gz
 .pnp.*
-
-styles.css


### PR DESCRIPTION
The file styles.css is currently not ignored. I think it should be? It's generated by `npm run build`.