### PR TITLE
Add retry to s2 service to account for possible traffic overload

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,16 @@
 {
-    "name": "annotated-bibliography-obsidian",
+    "name": "obsidian-scholar",
     "version": "1.3.1",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
+            "name": "obsidian-scholar",
             "version": "1.3.1",
             "license": "MIT",
+            "dependencies": {
+                "exponential-backoff": "^3.1.1"
+            },
             "devDependencies": {
                 "@types/node": "^20.8.3",
                 "@typescript-eslint/eslint-plugin": "^6.7.4",
@@ -1261,6 +1265,11 @@
             "engines": {
                 "node": ">=0.10.0"
             }
+        },
+        "node_modules/exponential-backoff": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/exponential-backoff/-/exponential-backoff-3.1.1.tgz",
+            "integrity": "sha512-dX7e/LHVJ6W3DE1MHWi9S1EYzDESENfLrYohG2G++ovZrYOkm4Knwa0mc1cn84xJOR4KEU0WSchhLbd0UklbHw=="
         },
         "node_modules/fast-deep-equal": {
             "version": "3.1.3",
@@ -2995,6 +3004,11 @@
             "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
             "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
             "dev": true
+        },
+        "exponential-backoff": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/exponential-backoff/-/exponential-backoff-3.1.1.tgz",
+            "integrity": "sha512-dX7e/LHVJ6W3DE1MHWi9S1EYzDESENfLrYohG2G++ovZrYOkm4Knwa0mc1cn84xJOR4KEU0WSchhLbd0UklbHw=="
         },
         "fast-deep-equal": {
             "version": "3.1.3",

--- a/package.json
+++ b/package.json
@@ -24,5 +24,8 @@
         "ts-node": "^10.9.1",
         "tslib": "^2.6.2",
         "typescript": "^5.2.2"
+    },
+    "dependencies": {
+        "exponential-backoff": "^3.1.1"
     }
 }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -5,7 +5,7 @@ export const ARXIV_BIBTEX_API = "https://arxiv.org/bibtex/";
 export const ARXIV_REST_API = "https://export.arxiv.org/api/query?id_list=";
 export const ARXIV_URL_SUFFIX_ON_S2 = "arXiv:";
 export const ACL_ANTHOLOGY_URL_SUFFIX_ON_S2 = "ACL:";
-export const SEMANTIC_SCHOLAR_FIELDS = "fields=authors,title,abstract,url,venue,year,publicationDate,externalIds,isOpenAccess,openAccessPdf,citationStyles&limit=50";
+export const SEMANTIC_SCHOLAR_FIELDS = "fields=authors,title,abstract,url,venue,year,publicationDate,externalIds,isOpenAccess,openAccessPdf,citationStyles&limit=5";
 export const SEMANTIC_SCHOLAR_API = "https://api.semanticscholar.org/graph/v1/paper/";
 export const SEMANTIC_SCHOLAR_SEARCH_API = "https://api.semanticscholar.org/graph/v1/paper/search/?query=";
 export const SEMANTIC_SCHOLAR_REFERENCE_SEARCH_FIELDS = "/references?fields=authors,title,abstract,url,venue,year,publicationDate,externalIds,isOpenAccess,openAccessPdf,citationStyles&limit=50"

--- a/src/paperData.ts
+++ b/src/paperData.ts
@@ -10,6 +10,8 @@ import {
 } from "./constants";
 import { request } from "obsidian";
 import { trimString } from "./utility";
+import { backOff } from "exponential-backoff";
+import { Notice } from "obsidian";
 
 export interface StructuredPaperData {
 	title: string;
@@ -31,13 +33,38 @@ function getIdentifierFromUrl(url: string): string {
 	return url.split("/").slice(-1)[0];
 }
 
+async function makeRequestWithRetry(url: string): Promise<any> {
+	const makeRequest = async () => {
+		const response = await request(url);
+		return response;
+	};
+  
+	return backOff(makeRequest, {
+		startingDelay: 1000, // b/c the default is 1000ms according to the semanticscholar API
+		numOfAttempts: 5,
+		retry: (e) => {
+		  console.log(e);
+		  if (e.message.includes("429")) {
+			new Notice("Rate limit exceeded. Trying again.");
+			return true;
+		  } else if (e.message.includes("404")) {
+			new Notice("The paper cannot be found on SemanticScholar. Stop trying.");
+		  	return false;
+		  } else {
+			return true;
+		  }
+		},
+	  });
+  };
+
+  
 export function getCiteKeyFromBibtex(bibtex: string) {
 	const match = bibtex.match(/@.*\{([^,]+)/);
 	return match ? match[1] : null;
 }
 
 export async function fetchArxivBibtex(arxivId: string) {
-	const bibtex = await request(ARXIV_BIBTEX_API + arxivId);
+	const bibtex = await makeRequestWithRetry(ARXIV_BIBTEX_API + arxivId);
 	return bibtex;
 }
 
@@ -45,7 +72,7 @@ export async function fetchArxivPaperDataFromUrl(
 	url: string
 ): Promise<StructuredPaperData> {
 	const arxivId = getIdentifierFromUrl(url);
-	const arxivData = await request(ARXIV_REST_API + arxivId);
+	const arxivData = await makeRequestWithRetry(ARXIV_REST_API + arxivId);
 
 	const parser = new DOMParser();
 	const xmlDoc = parser.parseFromString(arxivData, "text/xml");
@@ -157,23 +184,7 @@ export async function fetchSemanticScholarPaperDataFromUrl(
 		throw new Error("Invalid url: " + url);
 	}
 
-	let retryCount = 0;
-	async function makeRequest(url: string): Promise<any> {
-		try {
-			const response = await request(url);
-			return response;
-		} catch (error) {
-			if (retryCount < maxRetryCount) {
-				retryCount++;
-				await new Promise((resolve) => setTimeout(resolve, retryDelay));
-				return makeRequest(url);
-			} else {
-				throw new Error("Max retry count exceeded");
-			}
-		}
-	}
-
-	let s2Data = await makeRequest(SEMANTIC_SCHOLAR_API + s2Id + "?" + SEMANTIC_SCHOLAR_FIELDS);
+	let s2Data = await makeRequestWithRetry(SEMANTIC_SCHOLAR_API + s2Id + "?" + SEMANTIC_SCHOLAR_FIELDS);
 
 	let json = JSON.parse(s2Data);
 
@@ -194,7 +205,7 @@ export async function searchSemanticScholar(
 
 	// console.log(requestUrl);
 
-	let s2Data = await request(requestUrl);
+	let s2Data = await makeRequestWithRetry(requestUrl);
 	// console.log(s2Data);
 
 	let json = JSON.parse(s2Data);
@@ -226,7 +237,7 @@ export async function fetchSemanticScholarPaperReferences(
 		throw new Error("Invalid url: " + url);
 	}
 
-	let s2Data = await request(
+	let s2Data = await makeRequestWithRetry(
 		SEMANTIC_SCHOLAR_API + s2Id + SEMANTIC_SCHOLAR_REFERENCE_SEARCH_FIELDS
 	);
 


### PR DESCRIPTION
Solving https://github.com/lolipopshock/obsidian-scholar/issues/20 ; 

The issue is that for [SemanticSchoalr API](https://www.semanticscholar.org/product/api), there is a chance that "S2 will also restrict access to unauthenticated users when there is traffic overload". As such, retry the api call is necessary and this issue automates the retry. 