### PR TITLE
Feat: Add api skeleton

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -46,11 +46,16 @@ import {
 	DEFAULT_SETTINGS,
 } from "./settingsTab";
 import { ObsidianScholar } from "./obsidianScholar";
+import { ObsidianScholarApi } from "./obsidianScholarApi";
 
 // Main Plugin Entry Point
 export default class ObsidianScholarPlugin extends Plugin {
 	settings: ObsidianScholarPluginSettings;
 	obsidianScholar: ObsidianScholar;
+
+	get api(): ReturnType<typeof ObsidianScholarApi.GetApi> {
+		return ObsidianScholarApi.GetApi(this.app, this, this.obsidianScholar);
+	}
 
 	async onload() {
 		// console.log("Loading ObsidianScholar Plugin.");
@@ -308,7 +313,10 @@ class paperSearchModal extends SuggestModal<PaperSearchModelResult> {
 	async searchSemanticScholar(query: string) {
 		let searchResult: StructuredPaperData[] = [];
 		try {
-			searchResult = await searchSemanticScholar(query, this.settings.s2apikey);
+			searchResult = await searchSemanticScholar(
+				query,
+				this.settings.s2apikey
+			);
 		} catch (error) {
 			new Notice("Errors when downloading papers from Semanticscholar");
 			console.error(error);

--- a/src/obsidianScholarApi.ts
+++ b/src/obsidianScholarApi.ts
@@ -1,0 +1,64 @@
+import { App } from "obsidian";
+
+import type ObsidianScholarPlugin from "./main";
+import { isValidUrl, getSystemPathSeparator } from "./utility";
+import type { ObsidianScholar } from "./obsidianScholar";
+import {
+	StructuredPaperData,
+	fetchArxivPaperDataFromUrl,
+	fetchSemanticScholarPaperDataFromUrl,
+} from "./paperData";
+
+export class ObsidianScholarApi {
+	public static GetApi(
+		app: App,
+		plugin: ObsidianScholarPlugin,
+		scholar: ObsidianScholar
+	) {
+		return {
+			// Paper creation and management
+			createPaperNoteFromUrl: async (url: string) => {
+				return this.createPaperNoteFromUrl(app, plugin, scholar, url);
+			},
+		};
+	}
+
+	private static async createPaperNoteFromUrl(
+		app: App,
+		plugin: ObsidianScholarPlugin,
+		scholar: ObsidianScholar,
+		url: string
+	): Promise<void> {
+		if (!isValidUrl(url)) {
+			throw new Error("Invalid URL");
+		}
+		try {
+			const paperData: StructuredPaperData =
+				await this.fetchPaperMetadata(app, plugin, url);
+			await scholar.downloadAndSavePaperNotePDF(paperData);
+		} catch (error) {
+			console.error("Failed to create paper note:", error);
+			throw error;
+		}
+	}
+
+	private static async fetchPaperMetadata(
+		app: App,
+		plugin: ObsidianScholarPlugin,
+		url: string
+	): Promise<StructuredPaperData> {
+		let paperFetchFunction: Function;
+
+		if (url.includes("arxiv.org")) {
+			paperFetchFunction = fetchArxivPaperDataFromUrl;
+		} else {
+			paperFetchFunction = (url: string) =>
+				fetchSemanticScholarPaperDataFromUrl(
+					url,
+					plugin.settings.s2apikey
+				);
+		}
+
+		return await paperFetchFunction(url);
+	}
+}


### PR DESCRIPTION
Now `scholar` supports the following: 
```
this.app.plugins.plugins.scholar.api.createPaperNoteFromUrl(url="https://arxiv.org/abs/2311.09188")
```

You can use it in conjunction with the `advanced-uri` shortcut, and you can create paper notes externally: 
```
obsidian://adv-uri?eval=this.app.plugins.plugins.scholar.api.createPaperNoteFromUrl%28url%3D%22https%3A//arxiv.org/abs/2311.09188%22%29
```

Attribution: 
- This api design is inspired by https://github.com/chhoumann/quickadd/blob/master/src/quickAddApi.ts
- The advanced uri usage is inspired by https://github.com/chhoumann/quickadd/issues/256#issuecomment-1622289865