### PR TITLE
Fix: Add setting system path sep

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -59,6 +59,9 @@ export const SETTING_ADD_TO_BIB_FILE_NAME = "Save the BibTeX to";
 export const SETTING_ADD_TO_BIB_FILE_DESC = "Choose the .bib file to save the BibTeX to.";
 export const SETTING_ADD_TO_BIB_FILE_TARGET = "";
 
+export const SETTING_SYS_SEP = "System path separator";
+export const SETTING_SYS_SEP_DESC = "Used in the paper pdf path. Default is /; For Windows, use \\\\. Restart Obsidian after changing.";
+
 export const SETTING_NOTE_HEADER = "Note Settings";
 
 export const SETTING_FRONTMATTER_ADD_ALIASES_NAME = "Add aliases key in the note frontmatter?";

--- a/src/obsidianScholar.ts
+++ b/src/obsidianScholar.ts
@@ -29,7 +29,12 @@ export class ObsidianScholar {
 	) {
 		this.app = app;
 		this.settings = settings;
-		this.pathSep = pathSep ? pathSep : "/";
+		this.pathSep =
+			settings.pathSeparator !== ""
+				? (this.pathSep = settings.pathSeparator)
+				: pathSep
+				? pathSep
+				: "/";
 	}
 
 	constructFileName(paperData: StructuredPaperData): string {

--- a/src/settingsTab.ts
+++ b/src/settingsTab.ts
@@ -16,6 +16,8 @@ import {
 	SETTING_IS_ADD_TO_BIB_FILE_DESC,
 	SETTING_ADD_TO_BIB_FILE_NAME,
 	SETTING_ADD_TO_BIB_FILE_DESC,
+	SETTING_SYS_SEP,
+	SETTING_SYS_SEP_DESC,
 	SETTING_NOTE_HEADER,
 	SETTING_FRONTMATTER_ADD_ALIASES_NAME,
 	SETTING_FRONTMATTER_ADD_ALIASES_DESC,
@@ -41,6 +43,7 @@ export interface ObsidianScholarPluginSettings {
 	noteAddFrontmatterAliases: boolean;
 	noteAddFrontmatterAnnotation: boolean;
 	s2apikey: string;
+	pathSeparator: string;
 }
 
 export const DEFAULT_SETTINGS: ObsidianScholarPluginSettings = {
@@ -54,6 +57,7 @@ export const DEFAULT_SETTINGS: ObsidianScholarPluginSettings = {
 	noteAddFrontmatterAliases: false,
 	noteAddFrontmatterAnnotation: false,
 	s2apikey: "",
+	pathSeparator: "",
 };
 
 // Settings Tab
@@ -209,6 +213,19 @@ export class ObsidianScholarSettingTab extends PluginSettingTab {
 						})
 				);
 		}
+
+		new Setting(containerEl)
+			.setName(SETTING_SYS_SEP)
+			.setDesc(SETTING_SYS_SEP_DESC)
+			.addText((text) =>
+				text
+					.setPlaceholder("System path separator")
+					.setValue(this.plugin.settings.pathSeparator)
+					.onChange(async (value) => {
+						this.plugin.settings.pathSeparator = value;
+						await this.plugin.saveSettings();
+					})
+			);
 
 		containerEl.createEl("h2", { text: SETTING_NOTE_HEADER });
 


### PR DESCRIPTION
Fix for #25; 

While I've tried to determine the proper system separator in the following code, it seems not working perfectly and this caused issues for windows users? 
https://github.com/lolipopshock/obsidian-scholar/blob/3c74ae7ac4c4c763fbde67fcbc77e3bf11cca7f5/src/main.ts#L67 

A simple solution is just make it an explicit setting, and it can override the automatic detection. 
<img width="778" alt="image" src="https://github.com/user-attachments/assets/574a65f6-2d91-4d31-8d1d-b5762ed71f82" />
