### PR TITLE
Feat: Allow adding pdf to a paper + misc fixes

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -37,6 +37,9 @@ export const COMMAND_REMOVE_PAPER_NAME = "Remove Paper from Library";
 export const COMMAND_OPEN_PDF_IN_SYSTEM_APP = "open-pdf-in-system-app";
 export const COMMAND_OPEN_PDF_IN_SYSTEM_APP_NAME = "Open PDF in System App";
 
+export const COMMAND_ADD_PAPER_PDF = "add-paper-pdf";
+export const COMMAND_ADD_PAPER_PDF_NAME = "Add Paper PDF";
+
 
 // Settings 
 export const SETTING_GENERAL_HEADER = "Library Settings";
@@ -79,6 +82,9 @@ export const SETTING_TEMPLATE_FOLDER_DEFAULT = "template";
 
 export const SETTING_S2API_NAME = "Semantic Scholar API Key";
 export const SETTING_S2API_DESC = "Provide an Semantic Scholar API key can help you avoid rate limits when calling the API. You can obtain an API key from https://api.semanticscholar.org/.";
+
+export const SETTING_PDF_OVERRIDE_NAME = "Override existing PDFs";
+export const SETTING_PDF_OVERRIDE_DESC = "If enabled, adding a new PDF will replace the existing one. If disabled, the existing PDF will be renamed as a backup with timestamp.";
 
 // NOTICES 
 export const NOTICE_RETRIEVING_ARXIV = "Retrieving paper information from arXiv API.";

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -86,6 +86,9 @@ export const SETTING_S2API_DESC = "Provide an Semantic Scholar API key can help 
 export const SETTING_PDF_OVERRIDE_NAME = "Override existing PDFs";
 export const SETTING_PDF_OVERRIDE_DESC = "If enabled, adding a new PDF will replace the existing one. If disabled, the existing PDF will be renamed as a backup with timestamp.";
 
+export const SETTING_OPEN_PDF_AFTER_UPDATE_NAME = "Open PDF after update";
+export const SETTING_OPEN_PDF_AFTER_UPDATE_DESC = "If enabled, the PDF will be opened automatically after adding it to a paper.";
+
 // NOTICES 
 export const NOTICE_RETRIEVING_ARXIV = "Retrieving paper information from arXiv API.";
 export const NOTICE_RETRIEVING_S2 = "Retrieving paper information from Semantic Scholar API.";

--- a/src/main.ts
+++ b/src/main.ts
@@ -416,8 +416,16 @@ class paperSearchModal extends SuggestModal<PaperSearchModelResult> {
 			) as HTMLInputElement;
 			if (inputEl) {
 				inputEl.value = this.initialQuery;
-				// Trigger search immediately
-				this.searchSemanticScholar(this.initialQuery);
+				// Only trigger search if nothing is in the library
+				// In this case, we will try to compare the title with the library and if it is not found, we will search for it on Semantic Scholar
+				const title = this.initialQuery;
+				// We cannot use fuzzyTitleMatch directly on an array; instead, check if any local paper matches the title
+				const foundInLibrary = this.localPaperData.some(item =>
+					this.obsidianScholar.fuzzyTitleMatch(item.paper.title, title)
+				);
+				if (!foundInLibrary) {
+					this.searchSemanticScholar(this.initialQuery);
+				}
 			}
 		}
 	}

--- a/src/main.ts
+++ b/src/main.ts
@@ -31,6 +31,8 @@ import {
 	COMMAND_REMOVE_PAPER_NAME,
 	COMMAND_OPEN_PDF_IN_SYSTEM_APP,
 	COMMAND_OPEN_PDF_IN_SYSTEM_APP_NAME,
+	COMMAND_ADD_PAPER_PDF,
+	COMMAND_ADD_PAPER_PDF_NAME,
 	NOTICE_RETRIEVING_ARXIV,
 	NOTICE_RETRIEVING_S2,
 	NOTICE_SEARCH_BIBTEX_NOT_FOUND,
@@ -206,6 +208,18 @@ export default class ObsidianScholarPlugin extends Plugin {
 					}
 					return true;
 				}
+			},
+		});
+
+		this.addCommand({
+			id: COMMAND_ADD_PAPER_PDF,
+			name: COMMAND_ADD_PAPER_PDF_NAME,
+			callback: () => {
+				new addPaperPdfModal(
+					this.app,
+					this.settings,
+					this.obsidianScholar
+				).open();
 			},
 		});
 
@@ -1071,5 +1085,280 @@ class createNoteFromUrlModal extends Modal {
 			.finally(() => {
 				this.close();
 			});
+	}
+}
+
+// The Add Paper PDF Modal
+class addPaperPdfModal extends SuggestModal<PaperSearchModelResult> {
+	private settings: ObsidianScholarPluginSettings;
+	private obsidianScholar: ObsidianScholar;
+	private localPaperData: PaperSearchModelResult[] = [];
+
+	constructor(
+		app: App,
+		settings: ObsidianScholarPluginSettings,
+		obsidianScholar: ObsidianScholar
+	) {
+		super(app);
+		this.settings = settings;
+		this.obsidianScholar = obsidianScholar;
+
+		// Adding the instructions
+		const instructions = [
+			["↑↓", "to navigate"],
+			["↵", "to select paper"],
+			["esc", "to dismiss"],
+		];
+
+		const modalInstructionsHTML = this.modalEl.createEl("div", {
+			cls: "prompt-instructions",
+		});
+		for (const instruction of instructions) {
+			const modalInstructionHTML = modalInstructionsHTML.createDiv({
+				cls: "prompt-instruction",
+			});
+			modalInstructionHTML.createSpan({
+				cls: "prompt-instruction-command",
+				text: instruction[0],
+			});
+			modalInstructionHTML.createSpan({ text: instruction[1] });
+		}
+
+		this.setPlaceholder("Select paper to add PDF to");
+
+		// Get local papers and prioritize current file
+		this.localPaperData = this.app.vault
+			.getMarkdownFiles()
+			.filter((file) => file.path.startsWith(this.settings.NoteLocation))
+			.map((file, index) => {
+				return {
+					paper: this.obsidianScholar.getPaperDataFromLocalFile(file),
+					resultType: "local",
+					localFilePath: file.path,
+					paperIndex: index,
+				};
+			});
+
+		// Move current file to top if it's a paper note
+		const currentFile = this.app.workspace.getActiveFile();
+		if (currentFile && this.obsidianScholar.isFileInNoteLocation(currentFile)) {
+			const currentFileIndex = this.localPaperData.findIndex(
+				(item) => item.localFilePath === currentFile.path
+			);
+			if (currentFileIndex > -1) {
+				const currentPaper = this.localPaperData.splice(currentFileIndex, 1)[0];
+				this.localPaperData.unshift(currentPaper);
+			}
+		}
+	}
+
+	getSuggestions(query: string): PaperSearchModelResult[] {
+		if (query.length === 0) {
+			return this.localPaperData.slice(0, 10);
+		}
+
+		return this.localPaperData.filter((item) => {
+			const title = item.paper.title.toLowerCase();
+			const authors = item.paper.authors.join(" ").toLowerCase();
+			const searchTerm = query.toLowerCase();
+			return title.includes(searchTerm) || authors.includes(searchTerm);
+		}).slice(0, 10);
+	}
+
+	renderSuggestion(paper: PaperSearchModelResult, el: HTMLElement) {
+		const paperData = paper.paper;
+		
+		el.createEl("div", { text: paperData.title, cls: "paper-title" });
+		
+		if (paperData.authors.length > 0) {
+			el.createEl("div", { 
+				text: paperData.authors.join(", "), 
+				cls: "paper-authors" 
+			});
+		}
+		
+		if (paperData.venue) {
+			el.createEl("div", { text: paperData.venue, cls: "paper-venue" });
+		}
+	}
+
+	onChooseSuggestion(paper: PaperSearchModelResult, evt: MouseEvent | KeyboardEvent) {
+		new pdfPathInputModal(
+			this.app,
+			this.settings,
+			this.obsidianScholar,
+			paper.localFilePath!
+		).open();
+	}
+}
+
+// The PDF Input Modal
+class pdfPathInputModal extends SuggestModal<string> {
+	private settings: ObsidianScholarPluginSettings;
+	private obsidianScholar: ObsidianScholar;
+	private notePath: string;
+	private existingPdfPath: string | null = null;
+	private paperTitle: string;
+
+	constructor(
+		app: App,
+		settings: ObsidianScholarPluginSettings,
+		obsidianScholar: ObsidianScholar,
+		notePath: string
+	) {
+		super(app);
+		this.settings = settings;
+		this.obsidianScholar = obsidianScholar;
+		this.notePath = notePath;
+
+		// Get existing PDF path if any
+		const noteFile = this.app.vault.getAbstractFileByPath(notePath);
+		if (noteFile && noteFile instanceof TFile) {
+			const paperData = this.obsidianScholar.getPaperDataFromLocalFile(noteFile);
+			this.existingPdfPath = paperData.pdfPath || null;
+			this.paperTitle = paperData.title;
+		} else {
+			this.paperTitle = "Unknown Paper";
+		}
+
+		// Adding the instructions
+		const instructions = [
+			["↑↓", "to navigate"],
+			["↵", "to select/add PDF"],
+			["esc", "to dismiss"],
+		];
+
+		const modalInstructionsHTML = this.modalEl.createEl("div", {
+			cls: "prompt-instructions",
+		});
+		for (const instruction of instructions) {
+			const modalInstructionHTML = modalInstructionsHTML.createDiv({
+				cls: "prompt-instruction",
+			});
+			modalInstructionHTML.createSpan({
+				cls: "prompt-instruction-command",
+				text: instruction[0],
+			});
+			modalInstructionHTML.createSpan({ text: instruction[1] });
+		}
+
+		// Set placeholder based on existing PDF
+		if (this.existingPdfPath) {
+			this.setPlaceholder("Enter PDF URL or path (current PDF shown in suggestions)");
+		} else {
+			this.setPlaceholder("Enter PDF URL or local file path");
+		}
+
+		// Add description
+		const descEl = this.modalEl.createEl("div", {
+			cls: "add-paper-pdf-description",
+		});
+		
+		if (this.existingPdfPath) {
+			const behavior = this.settings.overridePdfs ? "replace" : "backup";
+			const behaviorText = this.settings.overridePdfs 
+				? "The existing PDF will be replaced." 
+				: "The existing PDF will be backed up with a timestamp.";
+			descEl.setText(`Adding PDF to "${this.paperTitle}". ${behaviorText}`);
+		} else {
+			descEl.setText(`Adding PDF to "${this.paperTitle}". Enter a URL to download or local path to copy.`);
+		}
+	}
+
+	getSuggestions(query: string): string[] {
+		const suggestions: string[] = [];
+		
+		// Add existing PDF path as first suggestion if it exists
+		if (this.existingPdfPath) {
+			suggestions.push(this.existingPdfPath);
+		}
+
+		// If query is empty, return just the existing path
+		if (!query.trim()) {
+			return suggestions;
+		}
+
+		// Add the current query as a suggestion (for custom paths/URLs)
+		if (query.trim() && !suggestions.includes(query.trim())) {
+			suggestions.push(query.trim());
+		}
+
+		// Add some common URL patterns if query looks like start of URL
+		if (query.startsWith("http")) {
+			const commonDomains = [
+				"https://arxiv.org/pdf/",
+				"https://www.semanticscholar.org/",
+				"https://aclanthology.org/",
+			];
+			
+			for (const domain of commonDomains) {
+				if (domain.startsWith(query) && !suggestions.includes(domain)) {
+					suggestions.push(domain);
+				}
+			}
+		}
+
+		return suggestions.slice(0, 5); // Limit to 5 suggestions
+	}
+
+	renderSuggestion(pdfPath: string, el: HTMLElement) {
+		const containerEl = el.createDiv({ cls: "pdf-path-suggestion" });
+		
+		// Check if this is the existing PDF path
+		const isExisting = pdfPath === this.existingPdfPath;
+		
+		if (isExisting) {
+			containerEl.createDiv({ 
+				text: pdfPath, 
+				cls: "pdf-path-existing" 
+			});
+			const behaviorText = this.settings.overridePdfs 
+				? "Current PDF (will be replaced)" 
+				: "Current PDF (will be backed up)";
+			containerEl.createDiv({ 
+				text: behaviorText, 
+				cls: "pdf-path-label" 
+			});
+		} else {
+			containerEl.createDiv({ 
+				text: pdfPath, 
+				cls: "pdf-path-new" 
+			});
+			
+			// Add label based on path type
+			let label = "";
+			if (pdfPath.startsWith("http")) {
+				label = "Download from URL";
+			} else if (pdfPath.startsWith("/") || pdfPath.startsWith("./") || pdfPath.startsWith("~/")) {
+				label = "Copy from local path";
+			} else {
+				label = "Add as path";
+			}
+			
+			// If there's an existing PDF, mention what will happen
+			if (this.existingPdfPath) {
+				const action = this.settings.overridePdfs ? "replace" : "backup";
+				label += ` (will ${action} existing)`;
+			}
+			
+			containerEl.createDiv({ 
+				text: label, 
+				cls: "pdf-path-label" 
+			});
+		}
+	}
+
+	async onChooseSuggestion(pdfPath: string, evt: MouseEvent | KeyboardEvent) {
+		if (!pdfPath.trim()) {
+			new Notice("Please enter a PDF URL or local path.");
+			return;
+		}
+
+		try {
+			await this.obsidianScholar.addPdfToPaper(this.notePath, pdfPath.trim());
+			this.close();
+		} catch (error) {
+			// Error is already handled in addPdfToPaper
+		}
 	}
 }

--- a/src/obsidianScholar.ts
+++ b/src/obsidianScholar.ts
@@ -103,7 +103,7 @@ export class ObsidianScholar {
 		return str.toLowerCase().trim().replace(/[^\w\s]/g, '').replace(/\s+/g, ' ');
 	}
 
-	private fuzzyTitleMatch(paperTitle: string, searchTitle: string): boolean {
+	public fuzzyTitleMatch(paperTitle: string, searchTitle: string): boolean {
 		const normalizedPaperTitle = this.normalizeSearchString(paperTitle);
 		const normalizedSearchTitle = this.normalizeSearchString(searchTitle);
 		

--- a/src/obsidianScholar.ts
+++ b/src/obsidianScholar.ts
@@ -16,9 +16,6 @@ import {
 import { getDate, splitBibtex, formatTimeString, parseBibString } from "./utility";
 import { StructuredPaperData, PaperLibraryCheckResult, PaperLibrarySearchParams } from "./paperData";
 import { exec } from "child_process";
-import { promises as fs } from "fs";
-import { join } from "path";
-import { homedir } from "os";
 
 export class ObsidianScholar {
 	settings: ObsidianScholarPluginSettings;
@@ -599,6 +596,17 @@ export class ObsidianScholar {
 	): Promise<string> {
 		return new Promise(async (resolve, reject) => {
 			try {
+				// Check if running on desktop platform
+				if (!Platform.isDesktop) {
+					reject("Local file copying is only available on desktop platforms. Please use URL downloads on mobile.");
+					return;
+				}
+
+				// Import Node.js modules only on desktop platforms
+				const { promises: fs } = await import("fs");
+				const { join } = await import("path");
+				const { homedir } = await import("os");
+
 				let pdfDownloadFolder = this.settings.pdfDownloadLocation;
 				let pdfSavePath = pdfDownloadFolder + this.pathSep + targetFilename + ".pdf";
 

--- a/src/settingsTab.ts
+++ b/src/settingsTab.ts
@@ -25,6 +25,8 @@ import {
 	SETTING_FRONTMATTER_ADD_ANNOTATION_DESC,
 	SETTING_S2API_NAME,
 	SETTING_S2API_DESC,
+	SETTING_PDF_OVERRIDE_NAME,
+	SETTING_PDF_OVERRIDE_DESC,
 	NOTICE_NOT_BIB_FILE,
 	NOTICE_NO_BIB_FILE_SELECTED,
 } from "./constants";
@@ -44,6 +46,7 @@ export interface ObsidianScholarPluginSettings {
 	noteAddFrontmatterAnnotation: boolean;
 	s2apikey: string;
 	pathSeparator: string;
+	overridePdfs: boolean;
 }
 
 export const DEFAULT_SETTINGS: ObsidianScholarPluginSettings = {
@@ -58,6 +61,7 @@ export const DEFAULT_SETTINGS: ObsidianScholarPluginSettings = {
 	noteAddFrontmatterAnnotation: false,
 	s2apikey: "",
 	pathSeparator: "",
+	overridePdfs: false,
 };
 
 // Settings Tab
@@ -129,6 +133,18 @@ export class ObsidianScholarSettingTab extends PluginSettingTab {
 					.setValue(this.plugin.settings.pdfDownloadLocation)
 					.onChange(async (value) => {
 						this.plugin.settings.pdfDownloadLocation = value;
+						await this.plugin.saveSettings();
+					})
+			);
+
+		new Setting(containerEl)
+			.setName(SETTING_PDF_OVERRIDE_NAME)
+			.setDesc(SETTING_PDF_OVERRIDE_DESC)
+			.addToggle((toggle) =>
+				toggle
+					.setValue(this.plugin.settings.overridePdfs)
+					.onChange(async (value) => {
+						this.plugin.settings.overridePdfs = value;
 						await this.plugin.saveSettings();
 					})
 			);

--- a/src/settingsTab.ts
+++ b/src/settingsTab.ts
@@ -27,6 +27,8 @@ import {
 	SETTING_S2API_DESC,
 	SETTING_PDF_OVERRIDE_NAME,
 	SETTING_PDF_OVERRIDE_DESC,
+	SETTING_OPEN_PDF_AFTER_UPDATE_NAME,
+	SETTING_OPEN_PDF_AFTER_UPDATE_DESC,
 	NOTICE_NOT_BIB_FILE,
 	NOTICE_NO_BIB_FILE_SELECTED,
 } from "./constants";
@@ -47,6 +49,7 @@ export interface ObsidianScholarPluginSettings {
 	s2apikey: string;
 	pathSeparator: string;
 	overridePdfs: boolean;
+	openPdfAfterUpdate: boolean;
 }
 
 export const DEFAULT_SETTINGS: ObsidianScholarPluginSettings = {
@@ -62,6 +65,7 @@ export const DEFAULT_SETTINGS: ObsidianScholarPluginSettings = {
 	s2apikey: "",
 	pathSeparator: "",
 	overridePdfs: false,
+	openPdfAfterUpdate: false,
 };
 
 // Settings Tab
@@ -145,6 +149,18 @@ export class ObsidianScholarSettingTab extends PluginSettingTab {
 					.setValue(this.plugin.settings.overridePdfs)
 					.onChange(async (value) => {
 						this.plugin.settings.overridePdfs = value;
+						await this.plugin.saveSettings();
+					})
+			);
+
+		new Setting(containerEl)
+			.setName(SETTING_OPEN_PDF_AFTER_UPDATE_NAME)
+			.setDesc(SETTING_OPEN_PDF_AFTER_UPDATE_DESC)
+			.addToggle((toggle) =>
+				toggle
+					.setValue(this.plugin.settings.openPdfAfterUpdate)
+					.onChange(async (value) => {
+						this.plugin.settings.openPdfAfterUpdate = value;
 						await this.plugin.saveSettings();
 					})
 			);

--- a/src/styles.css
+++ b/src/styles.css
@@ -51,3 +51,36 @@
 	display: inline-block;
 	margin-right: 5px;
 }
+
+.pdf-path-suggestion {
+	padding: var(--size-4-2);
+}
+
+.pdf-path-existing {
+	font-size: var(--font-ui-medium);
+	font-weight: var(--font-medium);
+	color: var(--text-accent);
+	margin-bottom: var(--size-4-1);
+}
+
+.pdf-path-new {
+	font-size: var(--font-ui-medium);
+	font-weight: var(--font-medium);
+	color: var(--text-normal);
+	margin-bottom: var(--size-4-1);
+}
+
+.pdf-path-label {
+	color: var(--text-faint);
+	font-size: var(--font-ui-small);
+	font-weight: var(--font-light);
+	font-style: italic;
+}
+
+/* Update the description styling for suggest modal */
+.modal-container .add-paper-pdf-description {
+	color: var(--text-faint);
+	margin-bottom: var(--size-4-3);
+	padding: 0 var(--size-4-3);
+	text-align: center;
+}


### PR DESCRIPTION
- Add a new command for adding or updating pdfs to a paper 
<img width="1352" alt="image" src="https://github.com/user-attachments/assets/6bdc1ea6-7f77-48e2-8fcb-82666f42983b" />

- Also fix an ui issue that it cannot properly open a paper when there's no opened notes 

- Also only search paper on semantic scholar when there's not an existing match in the library (in `openPaper` api). 