### PR TITLE
Fix Bug Caused by Other Notes in Scholar Folder

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -146,10 +146,11 @@ export default class ObsidianScholarPlugin extends Plugin {
 					return false;
 				} else {
 					if (!checking) {
-						let paperData =
+						let paperData = this.obsidianScholar.isValidScholarPaperNote(currentFile) ?
 							this.obsidianScholar.getPaperDataFromLocalFile(
 								currentFile
-							);
+							)
+							: null;
 
 						if (paperData && paperData.url) {
 							fetchSemanticScholarPaperReferences(
@@ -318,7 +319,8 @@ class paperSearchModal extends SuggestModal<PaperSearchModelResult> {
 
 		this.localPaperData = this.app.vault
 			.getMarkdownFiles()
-			.filter((file) => file.path.startsWith(this.settings.NoteLocation))
+			.filter((file) => file.path.startsWith(this.settings.NoteLocation)
+							&& this.obsidianScholar.isValidScholarPaperNote(file))
 			.map((file, index) => {
 				return {
 					paper: this.obsidianScholar.getPaperDataFromLocalFile(file),
@@ -761,7 +763,8 @@ class paperRemoveModal extends SuggestModal<PaperSearchModelResult> {
 
 		this.localPaperData = this.app.vault
 			.getMarkdownFiles()
-			.filter((file) => file.path.startsWith(this.settings.NoteLocation))
+			.filter((file) => file.path.startsWith(this.settings.NoteLocation)
+							&& this.obsidianScholar.isValidScholarPaperNote(file))
 			.map((file, index) => {
 				return {
 					paper: this.obsidianScholar.getPaperDataFromLocalFile(file),
@@ -1137,7 +1140,8 @@ class addPaperPdfModal extends SuggestModal<PaperSearchModelResult> {
 		// Get local papers and prioritize current file
 		this.localPaperData = this.app.vault
 			.getMarkdownFiles()
-			.filter((file) => file.path.startsWith(this.settings.NoteLocation))
+			.filter((file) => file.path.startsWith(this.settings.NoteLocation)
+							&& this.obsidianScholar.isValidScholarPaperNote(file))
 			.map((file, index) => {
 				return {
 					paper: this.obsidianScholar.getPaperDataFromLocalFile(file),
@@ -1221,7 +1225,7 @@ class pdfPathInputModal extends SuggestModal<string> {
 
 		// Get existing PDF path if any
 		const noteFile = this.app.vault.getAbstractFileByPath(notePath);
-		if (noteFile && noteFile instanceof TFile) {
+		if (noteFile && noteFile instanceof TFile && this.obsidianScholar.isValidScholarPaperNote(noteFile)) {
 			const paperData = this.obsidianScholar.getPaperDataFromLocalFile(noteFile);
 			this.existingPdfPath = paperData.pdfPath || null;
 			this.paperTitle = paperData.title;

--- a/src/obsidianScholar.ts
+++ b/src/obsidianScholar.ts
@@ -42,6 +42,25 @@ export class ObsidianScholar {
 		return paperData.title.replace(/[^a-zA-Z0-9 ]/g, "");
 	}
 
+	/**
+	 * Checks whether the given file is a valid Scholar paper note.
+	 * This is defined as the file having all three properties required by the StructuredPaperData interface.
+	 * @param file - the file for the note to check
+	 * @returns - whether the file has the three properties required by the StructuredPaperData interface.
+	 */
+	isValidScholarPaperNote(file: TFile): boolean {
+		// Get the file frontmatter.
+		let fileCache = this.app.metadataCache.getFileCache(file);
+		let frontmatter = fileCache?.frontmatter;
+
+		// Return whether the file has the three properties required
+		// 		by the StructuredPaperData interface.
+		return frontmatter &&
+			frontmatter.title &&
+			frontmatter.authors &&
+			frontmatter. abstract;
+	}
+
 	getPaperDataFromLocalFile(file: TFile): StructuredPaperData {
 		let fileCache = this.app.metadataCache.getFileCache(file);
 		let frontmatter = fileCache?.frontmatter;
@@ -57,7 +76,7 @@ export class ObsidianScholar {
 
 		return {
 			title: frontmatter?.title ?? file.basename,
-			authors: frontmatter?.authors.split(",") ?? [],
+			authors: frontmatter?.authors?.split(",") ?? [],
 			abstract: frontmatter?.abstract ?? null,
 			url: frontmatter?.url ?? null,
 			venue: frontmatter?.venue ?? null,
@@ -93,7 +112,8 @@ export class ObsidianScholar {
 	async getAllLocalPaperData(): Promise<StructuredPaperData[]> {
 		return this.app.vault
 			.getMarkdownFiles()
-			.filter((file) => file.path.startsWith(this.settings.NoteLocation))
+			.filter((file) => file.path.startsWith(this.settings.NoteLocation)
+							&& this.isValidScholarPaperNote(file))
 			.map((file) => {
 				return this.getPaperDataFromLocalFile(file);
 			});
@@ -164,7 +184,8 @@ export class ObsidianScholar {
 
 		const allPapersWithFiles = this.app.vault
 			.getMarkdownFiles()
-			.filter((file) => file.path.startsWith(this.settings.NoteLocation))
+			.filter((file) => file.path.startsWith(this.settings.NoteLocation)
+							&& this.isValidScholarPaperNote(file))
 			.map((file) => ({
 				paperData: this.getPaperDataFromLocalFile(file),
 				file: file,
@@ -275,6 +296,11 @@ export class ObsidianScholar {
 	async getPaperBibtex(file: TFile | string): Promise<string | undefined> {
 		if (typeof file === "string") {
 			file = this.app.vault.getAbstractFileByPath(file) as TFile;
+		}
+
+		// Verify the paper data is valid.
+		if (this.isValidScholarPaperNote(file) == false) {
+			return undefined;
 		}
 
 		let paperData = this.getPaperDataFromLocalFile(file);
@@ -460,7 +486,8 @@ export class ObsidianScholar {
 		let pdfPath = "";
 		if (
 			currentFile.extension == "md" &&
-			this.isFileInNoteLocation(currentFile)
+			this.isFileInNoteLocation(currentFile) &&
+			this.isValidScholarPaperNote(currentFile)
 		) {
 			let paperData = this.getPaperDataFromLocalFile(currentFile);
 			if (paperData.pdfPath) {
@@ -561,6 +588,10 @@ export class ObsidianScholar {
 				let noteFile = this.app.vault.getAbstractFileByPath(pathToFile);
 				if (noteFile == null || !(noteFile instanceof TFile)) {
 					new Notice("Note file not found.");
+					return;
+				}
+				if (this.isValidScholarPaperNote(noteFile) == false) {
+					new Notice("Given file is not a Scholar paper note.");
 					return;
 				}
 
@@ -752,6 +783,9 @@ export class ObsidianScholar {
 			let noteFile = this.app.vault.getAbstractFileByPath(notePath);
 			if (noteFile == null || !(noteFile instanceof TFile)) {
 				throw new Error("Note file not found.");
+			}
+			if (this.isValidScholarPaperNote(noteFile) == false) {
+				throw new Error("Given file is not a Scholar paper note.");
 			}
 
 			let paperData = this.getPaperDataFromLocalFile(noteFile);


### PR DESCRIPTION
Closes #31. Fixed a bug caused when a note missing the authors property is included in the Scholar note location.

This issue appears to be caused by a missing Optional Chaining operator (thus the error is caused when "authors" is null or undefined) in the `getPaperDataFromLocalFile()` on `ObsidianScholar`. That has been fixed.

More broadly, there was no validation performed that the given note conforms to the expected format (i.e. contains the expected properties). The existing code assumes that any note in the "Note Folder" (set in the Scholar settings) is a valid paper note, and thus an instance of `StructuredPaperData` can be be created from it.

All functions now validate that the file is a valid Scholar paper note before attempting to get the paper data. "Valid" is defined as having all three of the note properties required by the `StructuredPaperData` interface (title, authors, and abstract). This is implemented as its own function, `isValidScholarPaperNote()` on `ObsidianScholar`, so that the definition of "valid" (the check performed in that function) can be updated later as needed with minimal changes.

The main side effect of this change is that any notes that are not "valid" scholar paper notes (as defined above) are ignored. This is likely acceptable, however, as the operations in question really only make sense when performed on such valid notes.

Not sure what the performance cost is of reading the `app.metadataCache.getFileCache(file)` is, and this check adds an additional call to that function. There is a more performant way to do this (where the call is made once, and then the check is performed, before continuing the operation), but that is more logically complex (particularly when chaining `filter` and `map` operations) and the performance hit appears to be minimal in practice. May need to be evaluated with very large vaults/paper collections later on, however.